### PR TITLE
Avoid inline elements for selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var ClickToSelect = React.createClass({
   render: function() {
     var self = this;
     return React.createElement(
-      'span',
+      'div',
       {
         onClick: this.select,
         ref: function(target) {


### PR DESCRIPTION
Inline elements cause the selection to result in a trailing space. Using
block or inline-block elements instead do not include the trailing space.
