### PR TITLE
Build after a local install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "main": "dist/index.js",
   "scripts": {
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "build": "rm -rf dist && babel src -d dist"
   },
   "keywords": [


### PR DESCRIPTION
`prepare` behaves like `prepublish` used to: it runs before publishing and aftera local install. I ran into this because I'm installing this library from my github fork while waiting for requested changes to be merged.

https://docs.npmjs.com/misc/scripts#description