### PR TITLE
Optionally render children inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ when they're clicked.
 
 ## use
 
-```js
-<ClickToSelect>this text will be selected when clicked</ClickToSelect>
+```jsx
+<ClickToSelect>
+  this text will be selected when clicked
+</ClickToSelect>
+```
+
+By default ClickToSelect contains the children within a span element, but you
+can use a div instead:
+
+```jsx
+<ClickToSelect containerElement="div">
+  <p>this text will be selected when clicked</p>
+</ClickToSelect>
+```
+
+This avoids React warnings:
+
+```jsconsole
+validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ can use a div instead:
 
 ```jsx
 <ClickToSelect containerElement="div">
-  <p>this text will be selected when clicked</p>
+  <p>
+    this text will be selected when clicked
+  </p>
 </ClickToSelect>
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class ClickToSelect extends React.PureComponent {
   };
 
   render() {
-    const Element = { div, span }[this.props.containerElement];
+    const Element = this.props.containerElement === 'div' ? div : span;
 
     return (
       <Element ref={this.getRef} onClick={this.select}>

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class ClickToSelect extends React.PureComponent {
   };
 
   render() {
-    const Element = this.props.containerElement === 'div' ? div : span;
+    const Element = this.props.containerElement;
 
     return (
       <Element ref={this.getRef} onClick={this.select}>

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,15 @@ import PropTypes from 'prop-types';
  * the text within.
  */
 class ClickToSelect extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.any.isRequired,
+    block: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    block: true,
+  };
+
   select = e => {
     e.preventDefault();
     const range = document.createRange();
@@ -21,16 +30,14 @@ class ClickToSelect extends React.PureComponent {
   };
 
   render() {
+    const Element = this.props.block ? 'div' : 'span';
+
     return (
-      <div ref={this.getRef} onClick={this.select}>
+      <Element ref={this.getRef} onClick={this.select}>
         {this.props.children}
-      </div>
+      </Element>
     );
   }
 }
-
-ClickToSelect.propTypes = {
-  children: PropTypes.any.isRequired
-};
 
 export default ClickToSelect;

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,11 @@ import PropTypes from 'prop-types';
 class ClickToSelect extends React.PureComponent {
   static propTypes = {
     children: PropTypes.any.isRequired,
-    block: PropTypes.bool,
+    containerElement: PropTypes.oneOf(['span', 'div']),
   };
 
   static defaultProps = {
-    block: true,
+    containerElement: 'span',
   };
 
   select = e => {
@@ -30,7 +30,7 @@ class ClickToSelect extends React.PureComponent {
   };
 
   render() {
-    const Element = this.props.block ? 'div' : 'span';
+    const Element = { div, span }[this.props.containerElement];
 
     return (
       <Element ref={this.getRef} onClick={this.select}>


### PR DESCRIPTION
Fixes this React error, when ClickToSelect is used inside a `<p>` or other phrasing content.

```
validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

Fix #12