### PR TITLE
declare compatibility with react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "peerDependencies": {
     "prop-types": "^15.5.0 || ^16.0.0",
-    "react": "0.13.x || 0.14.x || ^15.0.0 || ^16.0.0"
+    "react": "0.13.x || 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
As far as I can tell this library does not need any changes to work with React 17, but trying to install it in a React 17 project causes an error `npm ERR! ERESOLVE unable to resolve dependency tree` unless you install with the `--force` flag. This PR just updates `peerDependencies` to declare compatibility with React 17.